### PR TITLE
[13174] Add Toggle Feature to Show/Hide Self Responses in Feedback Session

### DIFF
--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -35,7 +35,7 @@
               <strong>Other responses (to you): </strong>Responses are not visible to you.
             </div>
           </ng-template>
-          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length">
+          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length && !hideMyResponses">
             <strong>Your own responses (to others):</strong>
             <div *ngFor="let responseFromSelf of question.responsesFromSelf">
               <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone" [statistics]="question.questionStatistics"></tm-student-view-responses>

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -62,6 +62,9 @@ export class QuestionResponsePanelComponent {
   regKey: string = '';
 
   @Input()
+  hideMyResponses: boolean = false;
+
+  @Input()
   previewAsPerson: string = '';
 
   canUserSeeResponses(question: FeedbackQuestionModel): boolean {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -87,6 +87,7 @@
     </div>
     <tm-question-response-panel [questions]="questions" [session]="session"
                                 [intent]="intent" [regKey]="regKey" [previewAsPerson]="previewAsPerson"
+                                [hideMyResponses]="hideMyResponses"
     ></tm-question-response-panel>
   </div>
 </tm-loading-retry>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -74,7 +74,7 @@
 </div>
 
 <div class="toggle-container">
-    <input class="toggle-input" type="checkbox" id="hideMyResponses" >
+    <input class="toggle-input" type="checkbox" id="hideMyResponses" (change)="toggleHideSelfResponses($event)" >
     <label class="toggle-label" for="hideMyResponses">Hide my own responses</label>
 </div>
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -73,6 +73,11 @@
   </div>
 </div>
 
+<div class="toggle-container">
+    <input class="toggle-input" type="checkbox" id="hideMyResponses" >
+    <label class="toggle-label" for="hideMyResponses">Hide my own responses</label>
+</div>
+
 <tm-loading-retry [shouldShowRetry]="hasFeedbackSessionResultsLoadingFailed" [message]="'Failed to load results'" (retryEvent)="retryLoadingFeedbackSessionResults()">
   <div *tmIsLoading="isFeedbackSessionResultsLoading">
     <div *ngIf="questions.length === 0" class="mt-4">

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of, throwError } from 'rxjs';
 import SpyInstance = jest.SpyInstance;
@@ -36,6 +37,10 @@ import {
   StudentViewResponsesModule,
 } from '../../components/question-responses/student-view-responses/student-view-responses.module';
 import { QuestionTextWithInfoModule } from '../../components/question-text-with-info/question-text-with-info.module';
+import {
+  QuestionResponsePanelComponent
+} from "../../components/question-response-panel/question-response-panel.component";
+import {By} from "@angular/platform-browser";
 
 describe('SessionResultPageComponent', () => {
   const testFeedbackSession: FeedbackSession = {
@@ -119,6 +124,7 @@ describe('SessionResultPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        FormsModule,
         StudentViewResponsesModule,
         QuestionTextWithInfoModule,
         QuestionResponsePanelModule,
@@ -412,5 +418,71 @@ describe('SessionResultPageComponent', () => {
     });
     expect(component.questions.length).toEqual(1);
     expect(component.questions[0]).toEqual(testFeedbackQuestionModel);
+  });
+
+  // Test the toggle feature
+  it('should toggle `hideMyResponses` when the checkbox is clicked', () => {
+    // Arrange: Get the checkbox input element
+    const checkbox = fixture.debugElement.query(By.css('#hideMyResponses')).nativeElement;
+
+    // Act: Toggle the checkbox to hide responses
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    // Assert: The `hideMyResponses` should be true
+    expect(component.hideMyResponses).toBe(true);
+
+    // Act: Toggle the checkbox again to show responses
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    // Assert: The `hideMyResponses` should be false
+    expect(component.hideMyResponses).toBe(false);
+  });
+
+  it('should pass `hideMyResponses` to QuestionResponsePanelComponent correctly', () => {
+    // Arrange: Set `hideMyResponses` to true
+    component.hideMyResponses = true;
+    fixture.detectChanges();
+
+    // Act: Get the QuestionResponsePanelComponent instance
+    const questionResponsePanel = fixture.debugElement.query(By.directive(QuestionResponsePanelComponent))
+        .componentInstance as QuestionResponsePanelComponent;
+
+    // Assert: The `hideMyResponses` should be passed to the child component
+    expect(questionResponsePanel.hideMyResponses).toBe(true);
+
+    // Arrange: Set `hideMyResponses` to false
+    component.hideMyResponses = false;
+    fixture.detectChanges();
+
+    // Assert: The `hideMyResponses` should now be false in the child component
+    expect(questionResponsePanel.hideMyResponses).toBe(false);
+  });
+
+  it('should hide the self responses section when `hideMyResponses` is true', () => {
+    // Arrange: Set `hideMyResponses` to true
+    component.hideMyResponses = true;
+    fixture.detectChanges();
+
+    // Act: Query the responses section with class `given-responses`
+    const responseSection = fixture.debugElement.query(By.css('.given-responses'));
+
+    // Assert: Response section should not be present in the DOM
+    expect(responseSection).toBeNull();
+  });
+
+  it('should show the self responses section when `hideMyResponses` is false', () => {
+    // Arrange: Set `hideMyResponses` to false
+    component.hideMyResponses = false;
+    fixture.detectChanges();
+
+    // Act: Query the responses section with class `given-responses`
+    const responseSection = fixture.debugElement.query(By.css('.given-responses'));
+
+    // Assert: Response section should be present in the DOM
+    expect(responseSection).not.toBeNull();
   });
 });

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -108,6 +108,13 @@ export class SessionResultPageComponent implements OnInit {
 
   private backendUrl: string = environment.backendUrl;
 
+  hideMyResponses: boolean = false;
+
+  toggleHideSelfResponses(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.hideMyResponses = target.checked;
+  }
+
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,
               private feedbackSessionsService: FeedbackSessionsService,
               private route: ActivatedRoute,


### PR DESCRIPTION
Attempt to Fixes 13174 of [teamwork](https://github.com/TEAMMATES/teammates)

### Key Features Implemented

1. Toggle Checkbox for Self Responses:

    Added a toggle checkbox to the session result page (File edit: session-result-page.component.html).
    The checkbox controls a new boolean property, `hideMyResponses`, in `SessionResultPageComponent`.

2. Passing hideMyResponses to Child Components:

    Updated the `QuestionResponsePanelComponent `to accept an `@Input() hideMyResponses` property.
    The visibility of self responses is controlled based on the value of `hideMyResponses`.

3. UI Updates:

    The checkbox is implemented with custom styling classes (`toggle-container`, `toggle-input`, `toggle-label`).
    If hideMyResponses is set to true, the "self responses" section is hidden in the UI.

### Files Changed:

1.    session-result-page.component.html:

       Added the HTML for the toggle checkbox.
       Updated the QuestionResponsePanelComponent to pass the hideMyResponses property.

3.    session-result-page.component.ts:

        Added a `hideMyResponses `boolean property.
        Created a `toggleHideSelfResponses()` method to handle the change event from the checkbox.

4.    question-response-panel.component.ts:
        Updated to include an `@Input()` property called `hideMyResponses`.
        Modified the `ngIf `condition to control the visibility of self responses.

### Testing:

- Added unit tests to verify the correct behavior of the toggle feature.

- Tests include verifying the hideMyResponses property when the checkbox is toggled, and checking if the responses are correctly hidden or displayed in QuestionResponsePanelComponent.

- Updated the existing test suite (File changed: session-result-page.component.spec.ts) to include these new tests.
